### PR TITLE
Update dateformat.js to allow all time zones.

### DIFF
--- a/src/dateformat.js
+++ b/src/dateformat.js
@@ -15,7 +15,7 @@
 (function (global) {
   const dateFormat = (() => {
     const token = /d{1,4}|m{1,4}|yy(?:yy)?|([HhMsTt])\1?|[LlopSZWN]|"[^"]*"|'[^']*'/g;
-    const timezone = /\b(?:[PMCEA][SDP]T|(?:Pacific|Mountain|Central|Eastern|Atlantic) (?:Standard|Daylight|Prevailing) Time|(?:GMT|UTC)(?:[-+]\d{4})?)\b/g;
+    const timezone = /\b(?:[A-Z]{1,3}[A-Z]T|(?:Pacific|Mountain|Central|Eastern|Atlantic) (?:Standard|Daylight|Prevailing) Time|(?:GMT|UTC)(?:[-+]\d{4})?)\b/g;
     const timezoneClip = /[^-+\dA-Z]/g;
 
     // Regexes and supporting functions are cached through closure


### PR DESCRIPTION
Uses list of time zone abbreviations. https://en.wikipedia.org/wiki/List_of_time_zone_abbreviations